### PR TITLE
Update context menu accelerator keys for de Locale to avoid collisions

### DIFF
--- a/rss-ticker/chrome/locale/de/locale.dtd
+++ b/rss-ticker/chrome/locale/de/locale.dtd
@@ -2,11 +2,14 @@
 <!ENTITY rssticker.cm.open "Öffnen">
 <!ENTITY rssticker.cm.open.key "Ö">
 <!ENTITY rssticker.cm.openInNewWindow "In neuem Fenster öffnen">
-<!ENTITY rssticker.cm.openInNewWindow.key "F">
+<!ENTITY rssticker.cm.openInNewWindow.key "n">
 <!ENTITY rssticker.cm.openInNewTab "In neuem Tab öffnen">
+<!ENTITY rssticker.cm.openInNewTab.key "T">
 <!ENTITY rssticker.cm.openAllInTabs "Alle in Tabs öffnen">
+<!ENTITY rssticker.cm.openAllInTabs.key "A">
 <!ENTITY rssticker.cm.openUnreadInTabs "Alle ungelesenen in Tabs öffnen">
 <!ENTITY rssticker.cm.openFeedInTabs "Feed in Tabs öffnen">
+<!ENTITY rssticker.cm.openFeedInTabs.key "e">
 <!ENTITY rssticker.cm.openFeedUnreadInTabs "Ungelesene dieses Feeds in Tabs öffnen">
 <!ENTITY rssticker.cm.copyLinkTitle "Link-Titel kopieren">
 <!ENTITY rssticker.cm.copyLinkTitle.key "i">


### PR DESCRIPTION
As RSS Ticker 13 removed the option to hide entries in the context menu,
it was no longer possible to quickly mark a feed read by <right-click>+<f>.
