### PR TITLE
Fix invisible ticker popups on GTK themes with white font.

### DIFF
--- a/rss-ticker/chrome/skin/toolbar.css
+++ b/rss-ticker/chrome/skin/toolbar.css
@@ -28,8 +28,6 @@
 }
 
 #rss-ticker-tooltip {
-	-moz-appearance: none;
-	background-color: #fff;
 	width: 400px;
 	min-width: 400px;
 	max-width: 400px;


### PR DESCRIPTION
Esp. in dark GTK themes the forced white background makes it
impossible to read the white text.

This hotfix removes the explicit color declaration and allows
Firefox to use their default colors. I think this is a better
solution instead of assuming/forcing explicit colors.
