### PR TITLE
Remove superflous whitespaces in mousehove popup description.

### DIFF
--- a/rss-ticker/chrome/content/ticker-ui.js
+++ b/rss-ticker/chrome/content/ticker-ui.js
@@ -249,7 +249,9 @@ var RSS_TICKER_UI = {
 				var summary = document.getElementById( 'rss-ticker-tooltip-summary' );
 				while ( summary.lastChild )
 					summary.removeChild( summary.lastChild );
-				summary.appendChild( document.createTextNode( tickerItem.itemData.description ) );
+				var summaryText = tickerItem.itemData.description;
+				summaryText = summaryText ? summaryText.replace(/\s+/g, ' ') : "";	
+				summary.appendChild( document.createTextNode( summaryText ) );
 				document.getElementById( 'rss-ticker-tooltip-summary' ).style.display = '';
 			}
 			else {


### PR DESCRIPTION
On RSS feeds like http://heise.de.feedsportal.com/c/35207/f/653901/index.rss
(or maybe in general) the layout of the mouse hover is really ugly, as it
contained several trailing whitespace lines.

For an illustration see the attached sreenshots. Please note, that the colouring only illustrates for debugging purposes the container sizes.

Original (white color fix applied)
![rss-ws-problem](https://f.cloud.github.com/assets/588260/521811/5ad1eb84-bfd8-11e2-9c20-23d040f61847.png)

Fixed version
![fixed-ws](https://f.cloud.github.com/assets/588260/521812/8c924f92-bfd8-11e2-80de-968f3bc0a844.png)
